### PR TITLE
Add affiliate marketing section and AdSense placeholder

### DIFF
--- a/article1.html
+++ b/article1.html
@@ -41,6 +41,13 @@
 
 <h2>Jasper AI – generátor marketingových textů</h2>
 <p>Jasper AI (dříve Jarvis) je známý generátor marketingových textů. Dokáže psát copy v různých tonech na jakékoli téma, vytvářet úvodní verze e‑mailů, popisy produktů, příspěvky na blogu či reklamní slogany. Systém, který „přečetl“ velkou část internetu, slouží jako rychlý start, ale výstupy je vhodné upravit člověkem. Jasper je jednoduchý na použití a pomáhá udržovat vysoké SEO skóre【365242037376779†L275-L303】.</p>
+        <div class="affiliate-box">
+            <p><strong>Vyzkoušejte tyto nástroje:</strong></p>
+            <ul>
+                <li><a href="https://www.jasper.ai?ref=aimarketerhub" target="_blank" rel="nofollow">Jasper AI – získejte zdarma trial</a></li>
+                <li><a href="https://www.mailerlite.com/invite/aimarketerhub" target="_blank" rel="nofollow">MailerLite – jednoduchý e‑mail marketing</a></li>
+            </ul>
+        </div>
 
         <p><a href="index.html">← Zpět na hlavní stránku</a></p>
     </div>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,10 @@
         </nav>
     </header>
     <div class="container">
+        <!-- Google AdSense placeholder: replace CLIENT and SLOT with your own IDs -->
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-xxxxxxxxxxxx" crossorigin="anonymous"></script>
+        <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-xxxxxxxxxxxx" data-ad-slot="1234567890" data-ad-format="auto" data-full-width-responsive="true"></ins>
+        <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
         <img src="images/159f5f61-b16f-4380-89dd-b6632b7398c2.png" alt="AI marketing" class="article-img">
         <p>Vítejte na našem blogu o umělé inteligenci v marketingu. Naším cílem je ukázat vám, jak využít moderní AI nástroje a strategie k vytvoření vysoce ziskových projektů s minimálními vstupními náklady. V době, kdy se technologie neustále vyvíjejí, se správné informace a inovativní přístupy stávají klíčem k úspěchu. Pojďme se podívat, které nástroje, platformy a strategie vám mohou pomoci dosáhnout vysokých příjmů v online světě.</p>
 
@@ -38,6 +42,16 @@
             <li><a href="article6.html">Jak využít AI nástroje a drahá klíčová slova k zisku</a></li>
             <li><a href="article7.html">Statistiky a trendy AI marketingu v roce 2025</a></li>
         </ul>
+
+        <section class="affiliate-tools">
+            <h2>Doporučené nástroje</h2>
+            <p>Vyzkoušejte ověřené AI nástroje pro marketing:</p>
+            <ul>
+                <li><a href="https://www.jasper.ai?ref=aimarketerhub" target="_blank" rel="nofollow">Jasper AI – generátor marketingového obsahu</a></li>
+                <li><a href="https://www.mailerlite.com/invite/aimarketerhub" target="_blank" rel="nofollow">MailerLite – e‑mailová automatizace</a></li>
+                <li><a href="https://app.gumloop.com/?ref=aimarketerhub" target="_blank" rel="nofollow">Gumloop – no‑code integrace AI</a></li>
+            </ul>
+        </section>
     </div>
     <footer>
         <p>© 2025 AI Marketing Blog. Všechna práva vyhrazena.</p>

--- a/style.css
+++ b/style.css
@@ -128,6 +128,32 @@ body {
     box-shadow: 0 4px 12px rgba(0,0,0,0.08);
 }
 
+/* Affiliate tools section */
+.affiliate-tools {
+    margin-top: 60px;
+    padding: 20px;
+    background-color: var(--surface-color);
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+}
+
+.affiliate-tools ul {
+    margin: 0;
+    padding-left: 20px;
+}
+
+.affiliate-box {
+    margin: 40px 0;
+    padding: 20px;
+    background-color: #fff7e6;
+    border-left: 4px solid var(--accent-color);
+}
+
+.affiliate-box ul {
+    margin: 0;
+    padding-left: 20px;
+}
+
 /* Footer */
 footer {
     text-align: center;


### PR DESCRIPTION
## Summary
- Embed Google AdSense placeholder script and block on the homepage with a curated affiliate tools section.
- Add affiliate call-to-action box to the Jasper AI article to promote partner tools.
- Style new monetization blocks for consistent appearance with the site.

## Testing
- `tidy -q -e index.html`
- `tidy -q -e article1.html`


------
https://chatgpt.com/codex/tasks/task_e_68941359ba3c8332a4e1cd3d65adb96b